### PR TITLE
Command: add long living worker command

### DIFF
--- a/src/Command/QueueWorkerCommand.php
+++ b/src/Command/QueueWorkerCommand.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace EasyBib\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Uecode\Bundle\QPushBundle\Event\Events;
+use Uecode\Bundle\QPushBundle\Event\MessageEvent;
+use Uecode\Bundle\QPushBundle\Provider\ProviderRegistry;
+
+class QueueWorkerCommand extends Command
+{
+    /** @var ProviderRegistry */
+    private $registry;
+
+    /** @var OutputInterface */
+    private $output;
+
+    /** @var EventDispatcherInterface */
+    private $dispatcher;
+
+    public function __construct(ProviderRegistry $registry, EventDispatcherInterface $dispatcher)
+    {
+        parent::__construct();
+
+        $this->registry = $registry;
+        $this->dispatcher = $dispatcher;
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setName('uecode:qpush:worker')
+            ->setDescription('Polls the configured Queues')
+            ->addArgument('name', InputArgument::REQUIRED, 'Name of a specific queue to poll', null)
+            ->addOption('messages', 'm', InputOption::VALUE_OPTIONAL, 'Number of messages that should be processed before exit (default unlimited)')
+            ->addOption('sleep', 's', InputOption::VALUE_OPTIONAL, 'Sleep time in sec between polling (default none)', 0)
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->output = $output;
+        $name = $input->getArgument('name');
+        $processMessageLimit = $input->getOption('messages');
+        $sleep = $input->getOption('sleep');
+        $messageCounter = 0;
+        while ($processMessageLimit === null || $processMessageLimit >= $messageCounter) {
+            $messageCounter += $this->pollQueue($name);
+
+            if ($sleep) {
+                sleep($sleep);
+            }
+        }
+    }
+
+    private function pollQueue($name)
+    {
+        if (!$this->registry->has($name)) {
+            return $this->output->writeln(
+                sprintf('The [%s] queue you have specified does not exists!', $name)
+            );
+        }
+
+        $messages = $this->registry->get($name)->receive();
+        foreach ($messages as $message) {
+            $messageEvent = new MessageEvent($name, $message);
+            $this->dispatcher->dispatch(Events::Message($name), $messageEvent);
+        }
+
+        $msg = '<info>Finished polling %s Queue, %d messages fetched.</info>';
+        $this->output->writeln(sprintf($msg, $name, sizeof($messages)));
+
+        return count($messages);
+    }
+}

--- a/src/Command/QueueWorkerCommand.php
+++ b/src/Command/QueueWorkerCommand.php
@@ -50,6 +50,13 @@ class QueueWorkerCommand extends Command
         $name = $input->getArgument('name');
         $processMessageLimit = $input->getOption('messages');
         $sleep = $input->getOption('sleep');
+
+        if (!$this->registry->has($name)) {
+            return $this->output->writeln(
+                sprintf('<error>The [%s] queue you have specified does not exists!</error>', $name)
+            );
+        }
+
         $messageCounter = 0;
         while ($processMessageLimit === null || $processMessageLimit >= $messageCounter) {
             $messageCounter += $this->pollQueue($name);
@@ -62,12 +69,6 @@ class QueueWorkerCommand extends Command
 
     private function pollQueue($name)
     {
-        if (!$this->registry->has($name)) {
-            return $this->output->writeln(
-                sprintf('The [%s] queue you have specified does not exists!', $name)
-            );
-        }
-
         $provider = $this->registry->get($name);
         /** @var Message[] $messages */
         $messages = $provider->receive();

--- a/src/Command/QueueWorkerCommand.php
+++ b/src/Command/QueueWorkerCommand.php
@@ -11,7 +11,6 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Uecode\Bundle\QPushBundle\Event\Events;
 use Uecode\Bundle\QPushBundle\Event\MessageEvent;
 use Uecode\Bundle\QPushBundle\Message\Message;
-use Uecode\Bundle\QPushBundle\Provider\AwsProvider;
 use Uecode\Bundle\QPushBundle\Provider\ProviderRegistry;
 
 class QueueWorkerCommand extends Command
@@ -75,9 +74,6 @@ class QueueWorkerCommand extends Command
         foreach ($messages as $message) {
             $messageEvent = new MessageEvent($name, $message);
             $this->dispatcher->dispatch(Events::Message($name), $messageEvent);
-            if ($provider instanceof AwsProvider) {
-                $provider->delete($message->getMetadata()->get('ReceiptHandle'));
-            }
         }
 
         $msg = '<info>Finished polling %s Queue, %d messages fetched.</info>';

--- a/src/QPushServiceProvider.php
+++ b/src/QPushServiceProvider.php
@@ -162,7 +162,7 @@ class QPushServiceProvider implements ServiceProviderInterface, EventListenerPro
                 $dispatcher->addListener(Events::Message($name), $log);
                 $dispatcher->addListener(Events::Notification($name), $log);
 
-                if (isset($options['queue_name'])) {
+                if (isset($options['options']['queue_name'])) {
                     $dispatcher->addListener(Events::Notification($options['options']['queue_name']), $log);
                 }
             }
@@ -176,9 +176,23 @@ class QPushServiceProvider implements ServiceProviderInterface, EventListenerPro
                 $dispatcher->addListener(Events::Message($name), $handleEvent);
                 $dispatcher->addListener(Events::Notification($name), $handleEvent);
 
-                if (isset($options['queue_name'])) {
+                if (isset($options['options']['queue_name'])) {
                     $dispatcher->addListener(Events::Notification($options['options']['queue_name']), $log);
                 }
+            }
+
+            $handleMessageBuiltIn = function (Event $event) use ($app, $name) {
+                $provider = $app['uecode_qpush.queues'][$name];
+                call_user_func([$provider, 'onMessageReceived'], $event);
+            };
+            $handleNotificationBuiltIn = function (Event $event) use ($app, $name) {
+                $provider = $app['uecode_qpush.queues'][$name];
+                call_user_func([$provider, 'onMessageReceived'], $event);
+            };
+            $dispatcher->addListener(Events::Message($name), $handleMessageBuiltIn, 255);
+            $dispatcher->addListener(Events::Notification($name), $handleNotificationBuiltIn, 255);
+            if (isset($options['options']['queue_name'])) {
+                $dispatcher->addListener(Events::Notification($options['options']['queue_name']), $handleNotificationBuiltIn, 255);
             }
         }
     }

--- a/src/QPushServiceProvider.php
+++ b/src/QPushServiceProvider.php
@@ -3,6 +3,7 @@
 namespace EasyBib;
 
 use Doctrine\Common\Cache\ArrayCache;
+use EasyBib\Command\QueueWorkerCommand;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 use Silex\Api\EventListenerProviderInterface;
@@ -122,6 +123,10 @@ class QPushServiceProvider implements ServiceProviderInterface, EventListenerPro
             $command->setContainer($pimple['uecode_qpush.command.container']);
 
             return $command;
+        };
+
+        $pimple['uecode_qpush.command.worker'] = function (Container $pimple) {
+            return new QueueWorkerCommand($pimple['uecode_qpush'], $pimple['dispatcher']);
         };
     }
 

--- a/src/QPushServiceProvider.php
+++ b/src/QPushServiceProvider.php
@@ -181,6 +181,7 @@ class QPushServiceProvider implements ServiceProviderInterface, EventListenerPro
                 }
             }
 
+            // Register built in message/notification listener
             $handleMessageBuiltIn = function (Event $event) use ($app, $name) {
                 $provider = $app['uecode_qpush.queues'][$name];
                 call_user_func([$provider, 'onMessageReceived'], $event);


### PR DESCRIPTION
Worker process to pull more than just once from the queue.
Sleep is necessary for fake sqs because it doesn't support long polling